### PR TITLE
refactor: add ruff rules for sorting imports

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -1,6 +1,12 @@
-from LSP.plugin import ClientConfig, Response, WorkspaceFolder
+from __future__ import annotations
+
+from LSP.plugin import ClientConfig
+from LSP.plugin import Response
+from LSP.plugin import WorkspaceFolder
 from LSP.plugin.core.protocol import InitializeResult
-from LSP.plugin.core.typing import cast, List, Optional
+from LSP.plugin.core.typing import cast
+from LSP.plugin.core.typing import List
+from LSP.plugin.core.typing import Optional
 from lsp_utils import NpmClientHandler
 import os
 import sublime

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,21 @@
 [tool.pyright]
-pythonVersion = '3.11'
+pythonVersion = "3.8"
 
 [tool.ruff]
 select = ["E", "F", "W"]
 ignore = ["F401"]
 line-length = 120
 target-version = 'py38'
+
+[tool.ruff.lint]
+# Enable preview rules.
+preview = true
+select = ["F401", "I"]
+
+[tool.ruff.lint.isort]
+case-sensitive = false
+force-single-line = true
+from-first = true
+no-sections = true
+order-by-type = false
+required-imports = ["from __future__ import annotations"]


### PR DESCRIPTION
This is a semi-automatically created PR that adds ruff configuration for imports formatting.

It matches configuration included in the LSP package with the intention of consolidating import style across all LSP packages.

If you have strong preference to a different style, please keep the configuration but update it to your liking so that anyone working on the package does not have to guess the correct style to use. See [ruff isort settings](https://docs.astral.sh/ruff/settings/#lintisort).

(Since this PR was created semi-automatically, it might require some changes before being considered ready.)